### PR TITLE
Issue #11 - Invalid key type

### DIFF
--- a/src/communex/compat/key.py
+++ b/src/communex/compat/key.py
@@ -144,6 +144,7 @@ def local_key_addresses() -> dict[str, Ss58Address]:
     for key_name in key_names:
         # issue #11 https://github.com/agicommies/communex/issues/12 added check for key2address to stop error from being thrown by wrong key type. 
         if key_name == "key2address": 
+            print("key2address is saved in an invalid format. It will be ignored.")
             continue
         key_dict = classic_load_key(key_name)
         addresses_map[key_name] = check_ss58_address(key_dict.ss58_address)

--- a/src/communex/compat/key.py
+++ b/src/communex/compat/key.py
@@ -142,6 +142,9 @@ def local_key_addresses() -> dict[str, Ss58Address]:
     addresses_map: dict[str, Ss58Address] = {}
 
     for key_name in key_names:
+        # issue #11 https://github.com/agicommies/communex/issues/12 added check for key2address to stop error from being thrown by wrong key type. 
+        if key_name == "key2address": 
+            continue
         key_dict = classic_load_key(key_name)
         addresses_map[key_name] = check_ss58_address(key_dict.ss58_address)
 


### PR DESCRIPTION
Added check for key2address to stop error from being thrown from wrong key type
Comx key balances would throw an error because key2address was in the incorrect format for it to check the values of. I added a conditional check for the name=="key2address" to handle this edge case. 
A more robust solution will need to be found if you want to actually check the balance of key2address rather than just omit it from the balances. 